### PR TITLE
Fix ImportError: add openpyxl to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 streamlit
 graphviz
 pandas
+openpyxl


### PR DESCRIPTION
Pandas requires `openpyxl` to read Excel (.xlsx) files. Without it, the app 
fails with `ImportError` when uploading Excel files on Streamlit Cloud.

This update adds `openpyxl` to `requirements.txt` so the app runs correctly 
with Excel input.
